### PR TITLE
update File.exists? to File.exist?

### DIFF
--- a/lib/maily.rb
+++ b/lib/maily.rb
@@ -27,7 +27,7 @@ module Maily
 
       # Load hooks
       hooks_file_path = "#{Rails.root}/lib/maily_hooks.rb"
-      require hooks_file_path if File.exists?(hooks_file_path)
+      require hooks_file_path if File.exist?(hooks_file_path)
     end
 
     def hooks_for(mailer_name)


### PR DESCRIPTION
```File.exists?``` is deprecated in favor of ```File.exist?```.
http://ruby-doc.org/core-2.2.0/File.html#method-c-exist-3F