### PR TITLE
In new version of mail gem (2.7.1) the raw source of the email's body…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ sudo: false
 
 rvm:
   - ruby-head
-  - 2.5.1
-  - 2.4.4
-  - 2.3.6
-  - 2.2.9
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
+  - 2.2.10
 
 gemfile:
   - gemfiles/rails_5.2.gemfile

--- a/app/controllers/maily/emails_controller.rb
+++ b/app/controllers/maily/emails_controller.rb
@@ -23,7 +23,7 @@ module Maily
         @email.body
       end
 
-      render html: content.raw_source, layout: false
+      render html: content.raw_source.html_safe, layout: false
     end
 
     def attachment

--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -4,7 +4,7 @@ describe Maily::Mailer do
   let(:mailer) { Maily::Mailer.find('notifier') }
 
   it "should load mailers" do
-    expect(Maily::Mailer.all.keys).to eq(['application_mailer', 'notifier'])
+    expect(Maily::Mailer.all.keys).to include('application_mailer', 'notifier')
   end
 
   it "should build emails" do


### PR DESCRIPTION
… returns "unsafe" html, so mark it as trusted safe.

More information in: https://github.com/markets/maily/issues/32

Closes #32