### PR TITLE
Allow custom mailers via hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.5.3
   - 2.4.5
   - 2.3.8
-  - 2.2.10
 gemfile:
   - gemfiles/rails_5.2.gemfile
   - gemfiles/rails_5.1.gemfile
@@ -15,5 +14,3 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: 2.6.0
-      gemfile: gemfiles/rails_4.2.gemfile

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Maily
 
-[![Gem Version](https://badge.fury.io/rb/maily.svg)](http://badge.fury.io/rb/maily)
+[![Gem](https://img.shields.io/gem/v/maily.svg?style=flat-square)](https://rubygems.org/gems/maily)
 [![Build Status](https://travis-ci.org/markets/maily.svg?branch=master)](https://travis-ci.org/markets/maily)
 [![Maintainability](https://api.codeclimate.com/v1/badges/fff01b2137fd73070b14/maintainability)](https://codeclimate.com/github/markets/maily/maintainability)
 
@@ -136,6 +136,20 @@ You are also able to hide emails:
 ```ruby
 Maily.hooks_for('Notifier') do |mailer|
   mailer.hide_email(:sensible_email, :secret_email)
+end
+```
+
+### External emails
+
+If you want to register and display in the UI, emails from external sources, like for example a gem, you can do it by adding a hook. Example:
+
+```ruby
+Maily.hooks_for('Devise::Mailer') do |mailer|
+  mailer.hide_email(:unlock_instructions)
+
+  mailer.register_hook(:reset_password_instructions, user, 'random_token')
+  mailer.register_hook(:confirmation_instructions, user, 'random_token')
+  mailer.register_hook(:password_change, user)
 end
 ```
 

--- a/lib/maily.rb
+++ b/lib/maily.rb
@@ -33,8 +33,8 @@ module Maily
     end
 
     def hooks_for(mailer_name)
-      mailer = Maily::Mailer.find(mailer_name.underscore)
-      return unless mailer
+      mailer_name = mailer_name.underscore
+      mailer = Maily::Mailer.find(mailer_name) || Maily::Mailer.new(mailer_name)
 
       yield(mailer) if block_given?
     end

--- a/spec/maily_spec.rb
+++ b/spec/maily_spec.rb
@@ -26,4 +26,17 @@ describe Maily do
       expect(Maily.allowed_action?(:deliver)).to be false
     end
   end
+
+  describe '#hooks_for' do
+    it "allows to register external hooks" do
+      class ExternalMailer < ActionMailer::Base
+        def external_email
+        end
+      end
+
+      Maily.hooks_for('ExternalMailer')
+
+      expect(Maily::Mailer.find('external_mailer').emails.count).to eq 1
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ RSpec.configure do |config|
   config.order = 'random'
 end
 
-
 # Rails 4.2 call `initialize` inside `recycle!`. However Ruby 2.6 doesn't allow calling `initialize` twice.
 # More info: https://github.com/rails/rails/issues/34790
 if RUBY_VERSION >= "2.6.0" && Rails.version < "5"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,18 @@ RSpec.configure do |config|
   config.mock_with :rspec
   config.order = 'random'
 end
+
+
+# Rails 4.2 call `initialize` inside `recycle!`. However Ruby 2.6 doesn't allow calling `initialize` twice.
+# More info: https://github.com/rails/rails/issues/34790
+if RUBY_VERSION >= "2.6.0" && Rails.version < "5"
+  module ActionController
+    class TestResponse < ActionDispatch::TestResponse
+      def recycle!
+        @mon_mutex_owner_object_id = nil
+        @mon_mutex = nil
+        initialize
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow custom mailers via `hooks_for` -> this allows to register emails from gems (without subclassing), for example, `Devise::Mailer`:

```ruby
Maily.hooks_for('Devise::Mailer') do |mailer|
  mailer.hide_email(:unlock_instructions)

  mailer.register_hook(:reset_password_instructions, user, 'random_token')
  mailer.register_hook(:confirmation_instructions, user, 'random_token')
  mailer.register_hook(:password_change, user)
end
```