### PR TITLE
Properly display text parts, by respecting line breaks

### DIFF
--- a/app/assets/stylesheets/maily/application.scss
+++ b/app/assets/stylesheets/maily/application.scss
@@ -180,6 +180,11 @@ footer.footer {
     }
   }
 
+  .welcome_message {
+    margin-top: 3em;
+    max-width: 80%;
+  }
+
   .button {
     box-sizing: border-box;
     -moz-box-sizing: border-box;

--- a/app/controllers/maily/emails_controller.rb
+++ b/app/controllers/maily/emails_controller.rb
@@ -17,13 +17,16 @@ module Maily
     end
 
     def raw
-      content = if @email.parts.present?
+      content = if @email.multipart?
         params[:part] == 'text' ? @email.text_part.body : @email.html_part.body
       else
         @email.body
       end
 
-      render html: content.raw_source.html_safe, layout: false
+      content = content.raw_source
+      content = view_context.simple_format(content) if @email.sub_type == 'plain' || params[:part] == 'text'
+
+      render html: content.html_safe, layout: false
     end
 
     def attachment

--- a/app/views/maily/emails/index.html.erb
+++ b/app/views/maily/emails/index.html.erb
@@ -1,2 +1,6 @@
 <h2><%= total_emails(@mailers) %> emails found</h2>
-<p><%= Maily.welcome_message %></p>
+<p>Use the menu on the left hand side of the screen to navigate through the different email templates.</p>
+
+<div class="welcome_message">
+  <%= Maily.welcome_message.to_s.html_safe %>
+</div>

--- a/app/views/maily/emails/show.html.erb
+++ b/app/views/maily/emails/show.html.erb
@@ -52,7 +52,7 @@
     <iframe class="mail_iframe" onload='resizeIframe(this)' src="<%= raw_maily_email_path(mailer: params[:mailer], email: params[:email], locale: params[:locale], part: params[:part]) %>" frameborder="1" width="100%"></iframe>
   <% end %>
 
-  <% if @email.attachments.present? %>
+  <% if @email.has_attachments? %>
     <ul class="mail_attachments">
       <li>Attachments:</li>
       <li>

--- a/lib/maily.rb
+++ b/lib/maily.rb
@@ -17,7 +17,7 @@ module Maily
       self.base_controller    = 'ActionController::Base'
       self.http_authorization = nil
       self.hooks_path         = "lib/maily_hooks.rb"
-      self.welcome_message    = "Use the menu on the left hand side of the screen to navigate through the different email templates."
+      self.welcome_message    = nil
     end
 
     def load_emails_and_hooks

--- a/spec/controllers_spec.rb
+++ b/spec/controllers_spec.rb
@@ -64,10 +64,16 @@ describe Maily::EmailsController, type: :controller do
   end
 
   describe 'GET #raw' do
-    it 'renders the template' do
+    it 'renders the template (HTML part)' do
       compatible_get :raw, mailer: 'notifier', email: 'invitation'
 
       expect(response.body).to match("<h1>Invitation</h1>")
+    end
+
+    it 'renders the template (TEXT part)' do
+      compatible_get :raw, mailer: 'notifier', email: 'only_text'
+
+      expect(response.body).to match("<p>Text part\n<br />with break lines</p>")
     end
   end
 end

--- a/spec/dummy/app/mailers/notifier.rb
+++ b/spec/dummy/app/mailers/notifier.rb
@@ -23,6 +23,10 @@ class Notifier < ApplicationMailer
     mail
   end
 
+  def only_text
+    mail
+  end
+
   def with_slim_template
     mail
   end

--- a/spec/dummy/app/views/notifier/only_text.text.erb
+++ b/spec/dummy/app/views/notifier/only_text.text.erb
@@ -1,0 +1,2 @@
+Text part
+with break lines

--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -8,7 +8,7 @@ describe Maily::Mailer do
   end
 
   it "should build emails" do
-    expect(mailer.emails.size).to eq(7)
+    expect(mailer.emails.size).to eq(8)
   end
 
   it "should find mailers by name" do

--- a/spec/maily_spec.rb
+++ b/spec/maily_spec.rb
@@ -10,6 +10,7 @@ describe Maily do
     expect(Maily.available_locales).to eq([:en, :es, :pt, :fr])
     expect(Maily.base_controller).to eq('ActionController::Base')
     expect(Maily.http_authorization).to be nil
+    expect(Maily.welcome_message).to be nil
   end
 
   describe '#allowed_action?' do


### PR DESCRIPTION
Use simple_format to convert line breaks to html.

**Original text part**
![Captura de pantalla 2019-03-28 a la(s) 20 41 15](https://user-images.githubusercontent.com/576701/55187666-ec6e2b80-5199-11e9-84a8-c4a714e72d8b.png)

## BEFORE 👇 
![Captura de pantalla 2019-03-28 a la(s) 20 38 34](https://user-images.githubusercontent.com/576701/55187518-8ed9df00-5199-11e9-814c-2264997aefcf.png)

## AFTER 👇 
![Captura de pantalla 2019-03-28 a la(s) 20 38 57](https://user-images.githubusercontent.com/576701/55187523-913c3900-5199-11e9-91e0-adab98622e8f.png)



