### PR TITLE
Support ActionMailer::Parameterized

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ Maily.hooks_for('Notifier') do |mailer|
 end
 ```
 
+### Use `params`
+
+Support for [`ActionMailer::Parameterized`](https://api.rubyonrails.org/classes/ActionMailer/Parameterized.html) is possible via `with_params` hash:
+
+```ruby
+message = -> { 'Hello!' }
+
+Maily.hooks_for('Notifier') do |mailer|
+  mailer.register_hook(:new_message, with_params: { message: message })
+end
+```
+
 ### External emails
 
 If you want to register and display in the UI, emails from external sources, like for example a gem, you can do it by adding a hook. Example:

--- a/lib/maily/email.rb
+++ b/lib/maily/email.rb
@@ -16,7 +16,7 @@ module Maily
       mailer.klass
     end
 
-    def parametered_mailer_klass
+    def parameterized_mailer_klass
       if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 1
         params = with_params && with_params.transform_values { |param| param.respond_to?(:call) ? param.call : param }
         mailer_klass.with(params)
@@ -81,9 +81,9 @@ module Maily
       *args = arguments && arguments.map { |arg| arg.respond_to?(:call) ? arg.call : arg }
 
       if args == [nil]
-        parametered_mailer_klass.public_send(name)
+        parameterized_mailer_klass.public_send(name)
       else
-        parametered_mailer_klass.public_send(name, *args)
+        parameterized_mailer_klass.public_send(name, *args)
       end
     end
 

--- a/spec/dummy/app/mailers/notifier.rb
+++ b/spec/dummy/app/mailers/notifier.rb
@@ -7,6 +7,11 @@ class Notifier < ApplicationMailer
     mail
   end
 
+  def new_message
+    @message = params[:message]
+    mail
+  end
+
   def recommendation(email)
     mail template_path: 'notifications'
   end

--- a/spec/dummy/app/views/notifications/new_message.html.erb
+++ b/spec/dummy/app/views/notifications/new_message.html.erb
@@ -1,0 +1,2 @@
+<h1>New message</h1>
+<%= @message %>

--- a/spec/dummy/lib/maily_hooks.rb
+++ b/spec/dummy/lib/maily_hooks.rb
@@ -1,7 +1,9 @@
 email = -> { 'foo@foo.com' }
+message = -> { 'Hello!' }
 
 Maily.hooks_for('Notifier') do |mailer|
   mailer.register_hook(:invitation, email)
+  mailer.register_hook(:new_message, with_params: { message: message })
   mailer.register_hook(:recommendation, template_path: 'notifications', description: 'description')
   mailer.register_hook(:custom_template_name, template_name: 'invitation')
   mailer.register_hook(:generic_welcome)

--- a/spec/email_spec.rb
+++ b/spec/email_spec.rb
@@ -41,6 +41,27 @@ describe Maily::Email do
     end
   end
 
+  context "with params" do
+    let (:email) { mailer.find_email('new_message') }
+
+    it "should not require hook" do
+      expect(email.required_arguments).to be_blank
+      expect(email.require_hook?).to be false
+    end
+
+    it 'should handle lazy params successfully' do
+      expect(email.with_params).to be_present
+      expect { email.call }.to_not raise_error
+    end
+
+    it 'should handle not lazy arguments successfully' do
+      allow(email).to receive(:message).and_return('Hello!')
+
+      expect(email.with_params).to be_present
+      expect { email.call }.to_not raise_error
+    end
+  end
+
   it "should handle template_path via hook" do
     email = mailer.find_email('recommendation')
 

--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -8,7 +8,7 @@ describe Maily::Mailer do
   end
 
   it "should build emails" do
-    expect(mailer.emails.size).to eq(8)
+    expect(mailer.emails.size).to eq(9)
   end
 
   it "should find mailers by name" do


### PR DESCRIPTION
Hello! :wave: 
This PR adds support for [`ActionMailer::Parameterized`](https://api.rubyonrails.org/classes/ActionMailer/Parameterized.html) introduced in Rails 5.1

I'm successfully using it in my project, but let me know if you still would want to improve it somehow :)

One thing I'm not sure about if it's right is that the hook is not required even if we use `params` in mail, but I don't know how to test for that :/