### PR TITLE
FIX for Sprockets v4:

### DIFF
--- a/lib/maily/engine.rb
+++ b/lib/maily/engine.rb
@@ -6,7 +6,8 @@ module Maily
     config.assets.precompile << %w(
       maily/application.css
       maily/logo.png
-      maily/icons/*.svg
+      maily/icons/globe.svg
+      maily/icons/paperclip.svg
     )
   end
 end


### PR DESCRIPTION
https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs

Existing config.assets.precompile settings will still work for string values (although it is discouraged), but if you were previously using regexp or proc values, they won't work at all with Sprockets 4, and if you try you'll get an exception raised that looks like NoMethodError: undefined method 'start_with?'