### PR TITLE
Don't show empty mailer classes in sidebar

### DIFF
--- a/app/views/maily/shared/_sidebar.html.erb
+++ b/app/views/maily/shared/_sidebar.html.erb
@@ -1,5 +1,6 @@
 <aside class="sidebar">
   <% @mailers.each do |mailer| %>
+    <% next if mailer.total_emails.zero? %>
     <section class="nav_list">
       <h3 class="nav_title"><%= "#{mailer.name.humanize} (#{mailer.total_emails})" %></h3>
       <ul>


### PR DESCRIPTION
Some mailer classes don't contain mailer methods, eg. `ApplicationMailer`. They are still shown in the sidebar with a zero count, which isn't particularly useful. In my case I have namespaced the mailers so there are quite a few empty headings.